### PR TITLE
Avoiding conflicts

### DIFF
--- a/css/pageslider.css
+++ b/css/pageslider.css
@@ -15,17 +15,17 @@
     transform: translate3d(0, 0, 0);
 }
 
-.page.left {
+.page.pos_left {
     -webkit-transform: translate3d(-100%, 0, 0);
     transform: translate3d(-100%, 0, 0);
 }
 
-.page.center {
+.page.pos_center {
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0);
 }
 
-.page.right {
+.page.pos_right {
     -webkit-transform: translate3d(100%, 0, 0);
     transform: translate3d(100%, 0, 0);
 }

--- a/pageslider.js
+++ b/pageslider.js
@@ -22,10 +22,10 @@ function PageSlider(container) {
         }
         if (state === stateHistory[l-2]) {
             stateHistory.pop();
-            this.slidePageFrom(page, 'left');
+            this.slidePageFrom(page, 'pos_left');
         } else {
             stateHistory.push(state);
-            this.slidePageFrom(page, 'right');
+            this.slidePageFrom(page, 'pos_right');
         }
 
     }
@@ -36,7 +36,7 @@ function PageSlider(container) {
         container.append(page);
 
         if (!currentPage || !from) {
-            page.attr("class", "page center");
+            page.attr("class", "page pos_center");
             currentPage = page;
             return;
         }
@@ -52,8 +52,8 @@ function PageSlider(container) {
         container[0].offsetWidth;
 
         // Position the new page and the current page at the ending position of their animation with a transition class indicating the duration of the animation
-        page.attr("class", "page transition center");
-        currentPage.attr("class", "page transition " + (from === "left" ? "right" : "left"));
+        page.attr("class", "page transition pos_center");
+        currentPage.attr("class", "page transition " + (from === "pos_left" ? "pos_right" : "pos_left"));
         currentPage = page;
     }
 


### PR DESCRIPTION
This is a very minor change : `center`, `left` & `right` classes are widely used and might conflict in code. 
I have added the `pos_` prefix to avoid having the code behaving unexpectedly
